### PR TITLE
Update pswp.js

### DIFF
--- a/src/pswp.js
+++ b/src/pswp.js
@@ -265,7 +265,7 @@ var initPhotoSwipeFromDOM = function(options) {
 		}
 		if (!pswp_open) {
 			galleryElements.each(function(){
-				if ($(this).children("img").length>0) {
+				if ($(this).children("img").length>0 && !$(this).parent().hasClass('type_video')) {
 					$(this).click(function(e){
 						openPhotoSwipe(parseInt($(this).first().attr('data-pswp-gid')));
 						return false;


### PR DESCRIPTION
Videos don't play in the Photoswipe viewer so check to make sure the parent element is not of class "type_video" before opening Photoswipe. Videos do play within default Lightbox, so that should be used.