### PR TITLE
added show title/caption feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,55 @@ An easy way to install it under Debian/Ubuntu:
 And uglify the file by running:
 `uglifyjs src/pswp.js > pswp/pswp.min.js`
 
+Title/Caption
+-------------
+
+You can enable/disable the usage of the image title/caption in the lightbox in
+the plugin setup.
+
+The image title will be used from the `alt` image attribute.
+
+If you want to add the caption or additional information to the image title
+you've to add a html element to the template.
+
+Simple caption:
+
+    <koken:link lightbox="true">
+      <koken:img />
+      <div class="item-caption" style="display: none">{{ content.caption }}</div>
+    </koken:link>
+
+Complex caption using the timestamp and exif data:
+
+    <koken:link lightbox="true">
+      <koken:img />
+      <div class="item-caption" style="display: none">
+        <koken:time />
+        |
+        <koken:exif>
+          <koken:not empty="exif.make">
+            {{ exif.make }},
+          </koken:not>
+           <koken:not empty="exif.model">
+            {{ exif.model }},
+          </koken:not>
+          <koken:not empty="exif.exposure">
+             {{ exif.exposure }},
+          </koken:not>
+          <koken:not empty="exif.aperture">
+            {{ exif.aperture }},
+          </koken:not>
+          <koken:not empty="exif.focal_length">
+            {{ exif.focal_length }},
+          </koken:not>
+          <koken:not empty="exif.iso_speed_ratings">
+            {{ exif.iso_speed_ratings }}
+          </koken:not>
+        </koken:exif>
+      </div>
+    </koken:link>
+
+
 Todo
 ----
 - Ajax/PHP calls for image details

--- a/plugin.php
+++ b/plugin.php
@@ -47,6 +47,7 @@ class MesphotosPhotoswipe extends KokenPlugin {
 		$pswp[] = '<script src="'.$this->get_url($ui_js).'"></script>';
 		$pswp[] = '<script src="'.$this->get_url($pswp_js).'"></script>';
 		$koken_options = Array(
+			'showTitle' => $this->data->show_title ? 'true' : 'false',
 			'sharing' => $sharing,
 			'triggerEl' => $this->get_triggerEl(),
 			'usingPillar' => $this->usingPillar(),

--- a/src/pswp.js
+++ b/src/pswp.js
@@ -10,6 +10,8 @@ var initPhotoSwipeFromDOM = function(options) {
 				item['_common'] = {
 					"msrc": $(this).attr('data-src') || $(this).attr('src')
 				};
+				item['title'] = $(this).attr('data-alt') || $(this).attr('alt');
+				item['caption'] = $(this).nextAll('.item-caption:first').html();
 				item.pid = base.split('/').slice(-3).join("-").slice(0,-1).toLowerCase();
 
 				jQuery.each($(this).attr('data-presets').split(" "), function(i,val) {
@@ -104,7 +106,15 @@ var initPhotoSwipeFromDOM = function(options) {
 					return 1;
 				}
 			},
-			 galleryPIDs: true
+			galleryPIDs: true,
+			addCaptionHTMLFn: function(item, captionEl, isFake) {
+				if(!koken_options.showTitle || !item.title) {
+					captionEl.children[0].innerHTML = '';
+					return false;
+				}
+				captionEl.children[0].innerHTML = item.title + (item.caption ? '<br/><small>' + item.caption + '</small>' : '');
+				return true;
+			}
 		};
 
 		if (fromURL) {


### PR DESCRIPTION
This feature will provide show title / show caption feature to the photoswipe plugin.
1. The title will be read from the alt/data-alt attribute of the `<koken:img />` tag
2. The caption is not included in the img-tag and not everybody wants to use the caption text field so we've to modify the template. Using `$(this).nextAll('.item-caption:first')` the next `item-caption` element will be taken. (In my case I use the caption for the timestamp + exif data). An example usage can be found in the updated README.md
3. Image without title will have no title and caption at all.

I've added an option to the plugin setup so you can enable/disable the use of "show title/caption" in the lightbox.

You can view the caption in action on my koken page:
http://photo.dotlan.net/
