### PR TITLE
"Rating Heart" overlain with fullscreen button by devices with pixel ratio > 1.1

### DIFF
--- a/pswp/default-skin/default-skin.css
+++ b/pswp/default-skin/default-skin.css
@@ -66,6 +66,9 @@
   .pswp--svg .pswp__button--arrow--left,
   .pswp--svg .pswp__button--arrow--right {
     background: none; } }
+  .pswp--svg .pswp__button--rating{
+    background: none;}
+
 
 .pswp__button--close {
   background-position: 0 -44px; }


### PR DESCRIPTION
Fixed *.svg background image for rating plugin to prevent overlain with
*.svg for .pwsp__button—fs on devices with a pixel ratio > 1.1